### PR TITLE
Force jar to always be downloaded

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -3,16 +3,18 @@
   file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=755
 
 - name: Fetch persister jar
-  get_url: dest={{monasca_jar_dir}}/monasca-persister.jar url="{{persister_tarball_base_url}}/monasca-persister-{{persister_version}}-shaded.jar"
+  get_url: dest={{monasca_jar_dir}}/monasca-persister.jar url="{{persister_tarball_base_url}}/monasca-persister-{{persister_version}}-shaded.jar" force=yes
   notify:
     - restart monasca-persister
+
+- name: create conf_dir
+  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=775
 
 - name: create conf_file from template
   template: dest={{persister_java_conf_file}} owner={{persister_user}} group={{monasca_group}} mode=640 src=persister-config.yml.j2
   notify:
     - restart monasca-persister
 
-# Note: the deb package comes with an upstart script used when the distribution is trusty.
 - name: create systemd config
   copy: dest={{persister_systemd_service}} owner=root group=root mode=644 src=monasca-persister-java.service
   notify:

--- a/templates/monasca-persister.conf.j2
+++ b/templates/monasca-persister.conf.j2
@@ -8,4 +8,4 @@ respawn
 
 setgid monasca
 setuid persister
-exec /usr/bin/java -Dfile.encoding=UTF-8 -Xmx8g -cp {{monasca_jar_dir}}/monasca-persister.jar:{{monasca_jar_dir}}/vertica/vertica_jdbc.jar monasca.persister.PersisterApplication server {{monasca_conf_dir}}/persister-config.yml
+exec /usr/bin/java -Dfile.encoding=UTF-8 -Xmx8g -cp {{monasca_jar_dir}}/monasca-persister.jar:{{monasca_jar_dir}}/vertica/vertica_jdbc.jar monasca.persister.PersisterApplication server {{ persister_java_conf_file }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
-persister_conf_dir: /etc/monasca
-persister_java_conf_file: /etc/monasca/persister-config.yml
-persister_python_conf_file: /etc/monasca/persister.conf
+monasca_conf_dir: /etc/monasca
+persister_java_conf_file: "{{ monasca_conf_dir }}/persister-config.yml"
+persister_python_conf_file: "{{ monasca_conf_dir }}/persister.conf"
 persister_systemd_service: /etc/systemd/system/monasca-persister.service
 persister_upstart_conf: /etc/init/monasca-persister.conf
 persister_user: persister


### PR DESCRIPTION
Ensure Monasca configuration directory gets created

Use monasca_conf_dir instead of persister_conf_dir

Use monasca_conf_dir in dependent variables

Use persister_java_conf_file instead of persister-config.yml in startup
script