### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,13 +8,13 @@
   user: name={{persister_user}} system=yes group={{monasca_group}}
 
 - name: create monasca log directory
-  file: path={{monasca_log_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{monasca_log_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: create persister log directory
-  file: path={{persister_log_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{persister_log_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: create conf_dir
-  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: Detect if this is a systemd based system
   command: cat /proc/1/comm

--- a/tasks/java_configure.yml
+++ b/tasks/java_configure.yml
@@ -2,7 +2,7 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: create vertica dir
-  file: path={{monasca_jar_dir}}/vertica state=directory owner=root group=root mode=755
+  file: path={{monasca_jar_dir}}/vertica state=directory owner=root group=root mode=0755
   when: database_type == 'vertica'
 
 - name: check if vertica jar exists
@@ -15,19 +15,19 @@
   when: database_type == 'vertica' and not status.stat.exists
 
 - name: Ensure vertica jdbc permissions
-  file: path={{monasca_jar_dir}}/vertica/vertica_jdbc.jar mode=644
+  file: path={{monasca_jar_dir}}/vertica/vertica_jdbc.jar mode=0644
   when: database_type == 'vertica'
 
 - name: create conf_dir
-  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: create conf_file from template
-  template: dest={{persister_java_conf_file}} owner={{persister_user}} group={{monasca_group}} mode=640 src=persister-config.yml.j2
+  template: dest={{persister_java_conf_file}} owner={{persister_user}} group={{monasca_group}} mode=0640 src=persister-config.yml.j2
   notify:
     - restart monasca-persister
 
 - name: create systemd startup script from template
-  template: dest={{persister_systemd_service}} owner=root group=root mode=644 src=monasca-persister-java.service.j2
+  template: dest={{persister_systemd_service}} owner=root group=root mode=0644 src=monasca-persister-java.service.j2
   notify:
     - restart monasca-persister
   when: use_systemd
@@ -36,7 +36,7 @@
   when: use_systemd
 
 - name: create upstart script from template
-  template: dest=/etc/init/monasca-persister.conf owner=root group=root mode=744 src=monasca-persister-java.conf.j2
+  template: dest=/etc/init/monasca-persister.conf owner=root group=root mode=0744 src=monasca-persister-java.conf.j2
   notify:
     - restart monasca-persister
   when: not use_systemd

--- a/tasks/java_install.yml
+++ b/tasks/java_install.yml
@@ -2,7 +2,7 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: create jar_dir
-  file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=755
+  file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=0755
 
 - name: Fetch persister jar
   get_url: dest={{monasca_jar_dir}}/monasca-persister.jar url="{{persister_tarball_base_url}}/monasca-persister-{{persister_version}}-shaded.jar" force=yes timeout=100

--- a/tasks/python_configure.yml
+++ b/tasks/python_configure.yml
@@ -2,18 +2,18 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: create conf_file from template
-  template: dest={{persister_python_conf_file}} owner={{persister_user}} group={{monasca_group}} mode=640 src=persister.conf.j2
+  template: dest={{persister_python_conf_file}} owner={{persister_user}} group={{monasca_group}} mode=0640 src=persister.conf.j2
   notify:
     - restart monasca-persister
 
 - name: create upstart script from template
-  template: dest={{persister_upstart_conf}} owner=root group=root mode=644 src=monasca-persister-python.conf.j2
+  template: dest={{persister_upstart_conf}} owner=root group=root mode=0644 src=monasca-persister-python.conf.j2
   notify:
     - restart monasca-persister
   when: not use_systemd
 
 - name: create systemd config from template
-  template: dest={{persister_systemd_service}} owner=root group=root mode=644 src=monasca-persister-python.service.j2
+  template: dest={{persister_systemd_service}} owner=root group=root mode=0644 src=monasca-persister-python.service.j2
   notify:
     - restart monasca-persister
   when: use_systemd


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
